### PR TITLE
chore: add duhaime to about

### DIFF
--- a/routes/about.js
+++ b/routes/about.js
@@ -145,6 +145,7 @@ function generateHTML(){
     'dribnet',
     'drifkin',
     'drzax',
+    'duhaime',
     'duhoang',
     'dwtkns',
     'ee2dev',


### PR DESCRIPTION
I love that roadtolarissa exists 🙂 

(Should it filter to just those gists with a `thumbnail.png`?)